### PR TITLE
mDNS Support

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,15 @@
     <link rel="stylesheet" type="text/css" href="css/style.css">
   </head>
   <body class="error">
-    
+
     <div id="dialog" class="hide">
       <div class="vertical-center" style="height: 45px; width: 80%;">
         <input type="text" id="input" />
         <input type="submit" id="submit" value="Set" />
+        <input type="checkbox" name="ble" value="BLE" />
+        <input type="checkbox" name="mdns" value="mDNS"/>
       </div>
-    
+
     </div>
 
     <div id="status"><ul><li id="message"></li></ul></div>

--- a/index.html
+++ b/index.html
@@ -13,8 +13,6 @@
       <div class="vertical-center" style="height: 45px; width: 80%;">
         <input type="text" id="input" />
         <input type="submit" id="submit" value="Set" />
-        <input type="checkbox" name="ble" value="BLE" />
-        <input type="checkbox" name="mdns" value="mDNS"/>
       </div>
 
     </div>

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ app.on('window-all-closed', () => {
   app.quit();
 });
 
-function setUrl(url, ws) {
+function setBleUrl(url, ws) {
   try {
     EddystoneBeacon.advertiseUrl(url);
     mainWindow.webContents.send('status', [url, 'Advertising', true]);
@@ -25,6 +25,7 @@ function setUrl(url, ws) {
       ws.send('ble advertising: ' + url);
     }
     console.log();
+    setMdnsUrl(url, ws)
   } catch (e) {
     console.log('error: ' + e);
     mainWindow.webContents.send('status', [e.message, 'Error', false]);
@@ -33,9 +34,12 @@ function setUrl(url, ws) {
     }
     console.log();
   }
+}
+
+function setMdnsUrl(url, ws) {
   try {
     let urlParts = url.split('/')
-    mdnsAd = new mdns.Advertisement(mdns.tcp('http'), 80, {
+    mdnsAd = new mdns.Advertisement(mdns.tcp(urlParts[0].replace(':', '')), 80, {
       name: url,
       txtRecord: {
         path: urlParts[3]
@@ -119,6 +123,6 @@ app.on('ready', () => {
   });
 
   ipc.on('set-url', (event, arg) => {
-    setUrl(arg);
+    setBleUrl(arg);
   });
 });

--- a/main.js
+++ b/main.js
@@ -6,7 +6,10 @@ let app = require('app'),
   WebSocketServer = require('ws').Server,
   wss = new WebSocketServer({ 'port': 1234 }),
   EddystoneBeacon = require('eddystone-beacon'),
-  mainWindow = null;
+  mainWindow = null,
+  mdns = require('mdns'),
+  mdnsAd = null;
+
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
@@ -17,11 +20,35 @@ function setUrl(url, ws) {
   try {
     EddystoneBeacon.advertiseUrl(url);
     mainWindow.webContents.send('status', [url, 'Advertising', true]);
-    console.log('advertising: ' + url);
+    console.log('ble advertising: ' + url);
     if (ws) {
-      ws.send('advertising: ' + url);
+      ws.send('ble advertising: ' + url);
     }
     console.log();
+  } catch (e) {
+    console.log('error: ' + e);
+    mainWindow.webContents.send('status', [e.message, 'Error', false]);
+    if (ws) {
+      ws.send('error: ' + e);
+    }
+    console.log();
+  }
+  try {
+    let urlParts = url.split('/')
+    mdnsAd = new mdns.Advertisement(mdns.tcp('http'), 80, {
+      name: url,
+      txtRecord: {
+        path: urlParts[3]
+      },
+      host: urlParts[2],
+      domain: 'local',
+      ip: urlParts[2]
+    })
+    mdnsAd.start()
+    console.log('mdns advertising: ' + url);
+    if (ws) {
+      ws.send('mdns advertising: ' + url);
+    }
   } catch (e) {
     console.log('error: ' + e);
     mainWindow.webContents.send('status', [e.message, 'Error', false]);
@@ -49,6 +76,7 @@ app.on('ready', () => {
           'accelerator': 'Command+S',
           'click': () => {
             EddystoneBeacon.stop();
+            mdnsAd.stop();
             mainWindow.webContents.send('status', ['Use bookmarklet or <span class="key" aria-label="command">&#8984;</span> + <span class="key">A</span> to enter', 'Waiting', true]);
           }
         },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "eddystone-beacon": "1.0.5",
+    "mdns": "^2.3.1",
     "ws": "1.0.1"
   }
 }


### PR DESCRIPTION
This adds mDNS support using node-mDNS.

You can see the service published using bonjour on OSX:
`dns-sd -B`

I did not add any UI components- do you think a user should have a choice in broadcast method? Be able to do both at the same time? 
